### PR TITLE
Wrap headers in CPP for use in CPP tests

### DIFF
--- a/autofff/generator.py
+++ b/autofff/generator.py
@@ -138,7 +138,9 @@ class SimpleFakeGenerator(BareFakeGenerator):
 			if self.includeFiles is not None:
 				incGuardBeginning += [ f'#include "{os.path.basename(f)}"\n' for f in self.includeFiles ]
 			incGuardBeginning += f'#include "{os.path.basename(self.originalHeader)}"\n\n'
+			incGuardBeginning += f"#ifdef __cplusplus\nextern \"C\" {{ \n #endif\n"
 			incGuardEnd = [
+				f"#ifdef __cplusplus\n}}\n#endif\n",
 				f"\n#endif /* {incGuard} */\n"
 			]
 			output.writelines(incGuardBeginning)


### PR DESCRIPTION
I've got a few parts of my system that use c++. A few of them need to import the autofff mocks. This wraps the headers for use in C++.